### PR TITLE
Fix mermaid syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,7 +812,7 @@ flowchart TB
     JWT --> Just[justifications: array]
     
     Just --> Obj1[Object 1:<br/>type: exnex_pdc_vc_v1<br/>credential: PDC VC JWT]
-    Just --> Obj2[Object 2:<br/>type: provider_treatment_relationship_v1<br/>patient: {...}<br/>provider: {...}<br/>relationship_context: ...]
+    Just --> Obj2[Object 2:<br/>type: provider_treatment_relationship_v1<br/>patient: example data<br/>provider: example data<br/>relationship_context: ...]
     
     NWID[NW-ID/PDC Service<br/>Issuer] -.->|Issues| Obj1
     


### PR DESCRIPTION
## Summary
- escape special characters inside README mermaid code
- validate all mermaid diagrams using mermaid-cli

## Testing
- `npx -y @mermaid-js/mermaid-cli -p /tmp/puppeteer.json -i README.md -o /tmp/out.svg`

------
https://chatgpt.com/codex/tasks/task_e_683f66bf77288329aaf1f701e4e9da93